### PR TITLE
Update plugin names

### DIFF
--- a/create-cordova-project.md
+++ b/create-cordova-project.md
@@ -71,8 +71,8 @@ title: Module 1&#58; Creating a Cordova Project
 1. Make sure you are in the **workshop** directory, and add basic plugins to your projects:
 
   ```
-  cordova plugin add org.apache.cordova.device
-  cordova plugin add org.apache.cordova.console
+  cordova plugin add cordova-plugin-device
+  cordova plugin add cordova-plugin-console
   ```
 
 1. Examine the directory structure under workshop.


### PR DESCRIPTION
The plugin names have since been renamed from org.apache.cordova.x to cordova-plugin-x, and it throws a funny error message out onto the console: 
`WARNING: org.apache.cordova.console has been renamed to cordova-plugin-console. You may not be getting the latest version! We suggest you 'cordova plugin rm org.apache.cordova.console' and 'cordova plugin add cordova-plugin-console'.`
`Fetching plugin "org.apache.cordova.console" via cordova plugins registry`
`Installing "org.apache.cordova.console" for android`  
...but your tutorial is wonderful, so I thought I'd do my part for keeping it updated.
